### PR TITLE
chore: Bruk navn framfor path for å skille apps

### DIFF
--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -13,11 +13,10 @@ const stripTrailingSlash = (str: string) =>
 
 const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
   const namePrefix = `/proxy/${api.name}`;
-  // Derive the app's servers base from the first path segment of api.path.
-  // e.g. '/fplos/forvaltning/api' → '/fplos' (matches servers[0].url in the spec).
+  // Første segment av api.path er applikasjonens context-path. Resten er path til forvaltningsgrensesnittet
+  // Context-path brukes i openapi/servers.uri
   // Used to correctly rewrite paths for "Try it out" calls — avoids path doubling
-  // caused by api.path containing both the servers base and the operation prefix.
-  const serverBase = api.path.slice(0, Math.max(0, api.path.indexOf("/", 1)));
+  const contextPath = api.path.slice(0, Math.max(0, api.path.indexOf("/", 1)));
 
   return {
     proxyReqOptDecorator: (options, request) => {
@@ -75,10 +74,10 @@ const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
       );
 
       // Spec fetch:  replace namePrefix with api.path  e.g. /proxy/fp-los → /fplos/forvaltning/api
-      // API calls:   replace namePrefix with serverBase  e.g. /proxy/fp-los → /fplos
+      // API calls:   replace namePrefix with contextPath  e.g. /proxy/fp-los → /fplos
       //              Using api.path here would double the path: /fplos/forvaltning/api/forvaltning/api/...
       const isSpecFetch = urlFromRequest.pathname.endsWith("/openapi.json");
-      const replacement = isSpecFetch ? api.path : serverBase;
+      const replacement = isSpecFetch ? api.path : contextPath;
       const pathFromRequest = urlFromRequest.pathname.replace(
         namePrefix,
         replacement,

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -17,7 +17,7 @@ const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
   // e.g. '/fplos/forvaltning/api' → '/fplos' (matches servers[0].url in the spec).
   // Used to correctly rewrite paths for "Try it out" calls — avoids path doubling
   // caused by api.path containing both the servers base and the operation prefix.
-  const serverBase = api.path.substring(0, api.path.indexOf("/", 1));
+  const serverBase = api.path.slice(0, Math.max(0, api.path.indexOf("/", 1)));
 
   return {
     proxyReqOptDecorator: (options, request) => {
@@ -104,8 +104,10 @@ const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
           const spec = JSON.parse(proxyResData.toString("utf8"));
           spec.servers = [{ url: namePrefix }];
           return JSON.stringify(spec);
-        } catch (e) {
-          logger.warning(`Failed to parse openapi.json for ${api.name}: ${e}`);
+        } catch (error) {
+          logger.warning(
+            `Failed to parse openapi.json for ${api.name}: ${error}`,
+          );
           return proxyResData;
         }
       }

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -11,15 +11,30 @@ const xNavCallId = "x_Nav-CallId";
 const stripTrailingSlash = (str: string) =>
   str.endsWith("/") ? str.slice(0, -1) : str;
 
-const proxyOptions = (api: ProxyConfig["apis"][0]) =>
-  ({
+const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
+  const namePrefix = `/proxy/${api.name}`;
+  // Derive the app's servers base from the first path segment of api.path.
+  // e.g. '/fplos/forvaltning/api' → '/fplos' (matches servers[0].url in the spec).
+  // Used to correctly rewrite paths for "Try it out" calls — avoids path doubling
+  // caused by api.path containing both the servers base and the operation prefix.
+  const serverBase = api.path.substring(0, api.path.indexOf("/", 1));
+
+  return {
     proxyReqOptDecorator: (options, request) => {
-      // I tilfelle headers er undefined.
       options.headers = options.headers ?? {};
       const requestTime = Date.now();
 
       options.headers[xNavCallId] = request.headers[xNavCallId] ?? ulid();
       options.headers[xTimestamp] = requestTime;
+
+      // For spec requests: prevent gzip (so JSON.parse works in userResDecorator)
+      // and strip cache headers (so backend always returns 200 with body, not 304)
+      if (request.originalUrl?.includes("/openapi.json")) {
+        options.headers["accept-encoding"] = "identity";
+        delete options.headers["if-none-match"];
+        delete options.headers["if-modified-since"];
+      }
+
       delete options.headers.cookie;
 
       return new Promise((resolve, reject) => {
@@ -58,7 +73,16 @@ const proxyOptions = (api: ProxyConfig["apis"][0]) =>
         req.originalUrl,
         `http://${req.headers.host}`,
       );
-      const pathFromRequest = urlFromRequest.pathname;
+
+      // Spec fetch:  replace namePrefix with api.path  e.g. /proxy/fp-los → /fplos/forvaltning/api
+      // API calls:   replace namePrefix with serverBase  e.g. /proxy/fp-los → /fplos
+      //              Using api.path here would double the path: /fplos/forvaltning/api/forvaltning/api/...
+      const isSpecFetch = urlFromRequest.pathname.endsWith("/openapi.json");
+      const replacement = isSpecFetch ? api.path : serverBase;
+      const pathFromRequest = urlFromRequest.pathname.replace(
+        namePrefix,
+        replacement,
+      );
 
       const queryString = urlFromRequest.searchParams.toString();
       const newPath =
@@ -71,8 +95,31 @@ const proxyOptions = (api: ProxyConfig["apis"][0]) =>
       );
       return newPath;
     },
+
+    // Rewrite servers[0].url to the name-based proxy path so Swagger UI routes
+    // all "Try it out" calls through /proxy/<name>/... instead of /fplos/...
+    userResDecorator: (_proxyRes, proxyResData, userReq) => {
+      if (userReq.originalUrl?.includes("/openapi.json")) {
+        try {
+          const spec = JSON.parse(proxyResData.toString("utf8"));
+          spec.servers = [{ url: namePrefix }];
+          return JSON.stringify(spec);
+        } catch (e) {
+          logger.warning(`Failed to parse openapi.json for ${api.name}: ${e}`);
+          return proxyResData;
+        }
+      }
+      return proxyResData;
+    },
+
     userResHeaderDecorator: (headers, userReq, userRes, proxyReq, proxyRes) => {
-      // FPSAK og TILBAKE sender er redirect med full hostname - dette må man modifisere slik at det går tilbake via proxy.
+      if (userReq.originalUrl?.includes("/openapi.json")) {
+        delete headers["content-length"];
+        delete headers["content-encoding"];
+        delete headers["etag"];
+        delete headers["last-modified"];
+      }
+      // FPSAK og TILBAKE sender redirect med full hostname — modifisere slik at det går tilbake via proxy.
       const location = proxyRes.headers.location;
       if (location?.includes(api.url)) {
         headers.location = location.split(api.url)[1];
@@ -89,6 +136,7 @@ const proxyOptions = (api: ProxyConfig["apis"][0]) =>
       }
       return headers;
     },
+
     proxyErrorHandler: function (err, res, next) {
       switch (err?.code) {
         case "ENOTFOUND": {
@@ -107,12 +155,13 @@ const proxyOptions = (api: ProxyConfig["apis"][0]) =>
         }
       }
     },
-  }) satisfies ProxyOptions;
+  };
+};
 
 export const setupProxies = (router: Router) => {
   for (const api of config.reverseProxyConfig.apis) {
     router.use(
-      `${api.path}/*splat`,
+      `/proxy/${api.name}/*splat`,
       (request, response, next) => {
         if (request.timedout) {
           logger.warning(`Request for ${request.originalUrl} timed out!`);

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -13,10 +13,6 @@ const stripTrailingSlash = (str: string) =>
 
 const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
   const namePrefix = `/proxy/${api.name}`;
-  // Første segment av api.path er applikasjonens context-path. Resten er path til forvaltningsgrensesnittet
-  // Context-path brukes i openapi/servers.uri
-  // Used to correctly rewrite paths for "Try it out" calls — avoids path doubling
-  const contextPath = api.path.slice(0, Math.max(0, api.path.indexOf("/", 1)));
 
   return {
     proxyReqOptDecorator: (options, request) => {
@@ -73,9 +69,15 @@ const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
         `http://${req.headers.host}`,
       );
 
+      // Første segment av api.path er applikasjonens context-path. Resten er path til forvaltningsgrensesnittet
+      // Context-path brukes i openapi/servers.uri - mens de enkelte endepunktene er uten contextpath
       // Spec fetch:  replace namePrefix with api.path  e.g. /proxy/fp-los → /fplos/forvaltning/api
       // API calls:   replace namePrefix with contextPath  e.g. /proxy/fp-los → /fplos
-      //              Using api.path here would double the path: /fplos/forvaltning/api/forvaltning/api/...
+      //              Ser man på openapi.json så er requestene uten context-path
+      const contextPath = api.path.slice(
+        0,
+        Math.max(0, api.path.indexOf("/", 1)),
+      );
       const isSpecFetch = urlFromRequest.pathname.endsWith("/openapi.json");
       const replacement = isSpecFetch ? api.path : contextPath;
       const pathFromRequest = urlFromRequest.pathname.replace(
@@ -95,8 +97,8 @@ const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
       return newPath;
     },
 
-    // Rewrite servers[0].url to the name-based proxy path so Swagger UI routes
-    // all "Try it out" calls through /proxy/<name>/... instead of /fplos/...
+    // Erstatter openapi sin servers[0].url med proxy/name slik at "Try-it-out" virker
+    // alle "Try it out" kalls kommer med /proxy/<name>/... som blir erstattet med contextpath.
     userResDecorator: (_proxyRes, proxyResData, userReq) => {
       if (userReq.originalUrl?.includes("/openapi.json")) {
         try {

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -12,7 +12,7 @@ export const setupRoutes = () => {
     customCss: config.swagger.customCss,
     swaggerOptions: {
       urls: config.reverseProxyConfig.apis.map((api) => ({
-        url: `${api.path}/openapi.json`,
+        url: `/proxy/${api.name}/openapi.json`,
         name: api.name,
       })),
       deepLinking: true,


### PR DESCRIPTION
Nåværende impl bruker path framfor navn for å skille apps. Videre er det problem med servers/0 som må matche
For å få til både fp-los og fp-los-gcp i nedtrekksmenyen, så måtte de antagelig bruke ulik context-path med alt det medfører
Denne implementerer en proxy-ing basert på navn og Try-it-out funker med lokale docker-bygg av swagger.
Eneste forskjellen er at man ved direkte bruk må si fpswagger.../proxy/fp-los-gcp/forvaltning/api/prosesstask/LIST framfor fpswagger.../fplos/forvaltning/api/prosesstask/LIST fra browser-adresse-linje.

Det finnes sikkert mer elegante måter - her antas det at første del av "path" er lik "servers" i openapi.json - men det er jo det vi legger opp til i vår openapi-bruk ved å sette .addServersItem((new Server()).url(contextPath))