### PR TITLE
chore: forbedring for å hente openapi.json direkte

### DIFF
--- a/.deploy/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/dev-gcp-teamforeldrepenger.json
@@ -76,7 +76,13 @@
       "path": "/fpformidling/forvaltning/api",
       "url": "http://fpformidling",
       "scope": "api://dev-gcp.teamforeldrepenger.fpformidling/swagger",
-      "name": "fp-formidling-gcp"
+      "name": "fp-formidling"
+    },
+    {
+      "path": "/fplos/forvaltning/api",
+      "url": "http://fplos",
+      "scope": "api://dev-gcp.teamforeldrepenger.fplos/swagger",
+      "name": "fp-los-gcp"
     }
   ]
 }

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -59,6 +59,7 @@ spec:
         - application: fpinntektsmelding
         - application: fpmottak
         - application: fpformidling
+        - application: fplos
       external:
         {{#each externals as |external|}}
         - host: "{{external}}"

--- a/.deploy/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/prod-gcp-teamforeldrepenger.json
@@ -74,7 +74,13 @@
       "path": "/fpformidling/forvaltning/api",
       "url": "http://fpformidling",
       "scope": "api://prod-gcp.teamforeldrepenger.fpformidling/swagger",
-      "name": "fp-formidling-gcp"
+      "name": "fp-formidling"
+    },
+    {
+      "path": "/fplos/forvaltning/api",
+      "url": "http://fplos",
+      "scope": "api://prod-gcp.teamforeldrepenger.fplos/swagger",
+      "name": "fp-fplos-gcp"
     }
   ]
 }

--- a/server/src/reverseProxy.ts
+++ b/server/src/reverseProxy.ts
@@ -71,15 +71,23 @@ const proxyOptions = (api: ProxyConfig["apis"][0]): ProxyOptions => {
 
       // Første segment av api.path er applikasjonens context-path. Resten er path til forvaltningsgrensesnittet
       // Context-path brukes i openapi/servers.uri - mens de enkelte endepunktene er uten contextpath
-      // Spec fetch:  replace namePrefix with api.path  e.g. /proxy/fp-los → /fplos/forvaltning/api
-      // API calls:   replace namePrefix with contextPath  e.g. /proxy/fp-los → /fplos
+      // Spec fetch:  replace namePrefix with api.path  e.g. /proxy/fp-los to /fplos/forvaltning/api
+      // API calls:   replace namePrefix with contextPath  e.g. /proxy/fp-los to /fplos
       //              Ser man på openapi.json så er requestene uten context-path
       const contextPath = api.path.slice(
         0,
         Math.max(0, api.path.indexOf("/", 1)),
       );
+      const apiPathSuffix = api.path.slice(contextPath.length); // e.g. "/forvaltning/api"
+      const pathAfterNamePrefix = urlFromRequest.pathname.slice(
+        namePrefix.length,
+      ); // e.g. "/forvaltning/api/openapi.json"
       const isSpecFetch = urlFromRequest.pathname.endsWith("/openapi.json");
-      const replacement = isSpecFetch ? api.path : contextPath;
+      // If the request already includes the full api path suffix (e.g. /forvaltning/api/openapi.json), only prepend contextPath
+      const replacement =
+        !isSpecFetch || pathAfterNamePrefix.startsWith(apiPathSuffix)
+          ? contextPath
+          : api.path;
       const pathFromRequest = urlFromRequest.pathname.replace(
         namePrefix,
         replacement,


### PR DESCRIPTION
Ting funker, men for å kunne hente openapi.json/yaml fra adresselinja via fpswagger så trengs denne
Da skriver man http://<fpswagger>/proxy/<appnavn som vist - fx fp-los>/forvaltning/api/openapi.json 